### PR TITLE
Small change to export Strum macros

### DIFF
--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -6,7 +6,7 @@ use device::{chrome::*, firefox::*, okhttp::*, opera::*, safari::*};
 #[cfg(feature = "emulation-serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "emulation-rand")]
-use strum_macros::VariantArray;
+pub use strum_macros::VariantArray;
 use typed_builder::TypedBuilder;
 
 macro_rules! define_enum {

--- a/src/emulation.rs
+++ b/src/emulation.rs
@@ -6,7 +6,9 @@ use device::{chrome::*, firefox::*, okhttp::*, opera::*, safari::*};
 #[cfg(feature = "emulation-serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "emulation-rand")]
-pub use strum_macros::VariantArray;
+use strum_macros::VariantArray;
+#[cfg(feature = "emulation-rand")]
+pub use strum::VariantArray;
 use typed_builder::TypedBuilder;
 
 macro_rules! define_enum {


### PR DESCRIPTION
Hey y'all! I could be mistaken here as I'm not all that experienced in writing libraries in Rust, but I _think_ this small change would make it so that a person who uses the `emulation-rand` feature could access `Emulation::VARIANTS` to make functions of their own.

Motivation: I'm using wreq-util for a project of mine and I wanted to create a "latest_in_family" function that could take a string like "Chrome" or "Firefox" and return you the variant that has the highest version number from the versions in the enum. I was able to do so by importing Strum to my own project, but I hadn't locked the version so later on when I ran  `cargo update` I ended up with two versions of it and all hell broke loose.

Overall it's not a huge deal and if this isn't the right way to solve that problem I'd love to learn how =D Side note, excited for the 3.0.0 release when the time comes, keep up the great work!