### PR TITLE
feat(emulate): Add Chrome/Edge 148，Opera 131，Safari 26-2/4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ flate2 = { version = "1.1.9", optional = true }
 zstd = { version = "0.13.3", optional = true }
 
 [dev-dependencies]
+wreq = { git = "https://github.com/0x676e67/wreq.git"}
 tokio = { version = "1.48.0", features = ["full"] }
 hyper = { version = "1.8.1", default-features = false, features = [
     "http1",

--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -58,6 +58,7 @@ define_enum!(
     Chrome145 => ("chrome_145", v145::emulation),
     Chrome146 => ("chrome_146", v146::emulation),
     Chrome147 => ("chrome_147", v147::emulation),
+    Chrome148 => ("chrome_148", v148::emulation),
 
     // Edge versions
     Edge101 => ("edge_101", edge101::emulation),
@@ -78,6 +79,7 @@ define_enum!(
     Edge145 => ("edge_145", edge145::emulation),
     Edge146 => ("edge_146", edge146::emulation),
     Edge147 => ("edge_147", edge147::emulation),
+    Edge148 => ("edge_148", edge148::emulation),
 
     // Opera versions
     Opera116 => ("opera_116", opera116::emulation),
@@ -95,6 +97,7 @@ define_enum!(
     Opera128 => ("opera_128", opera128::emulation),
     Opera129 => ("opera_129", opera129::emulation),
     Opera130 => ("opera_130", opera130::emulation),
+    Opera131 => ("opera_131", opera131::emulation),
 
     // Firefox versions
     Firefox109 => ("firefox_109", ff109::emulation),
@@ -140,6 +143,8 @@ define_enum!(
     Safari26 => ("safari_26", safari26::emulation),
     Safari26_1 => ("safari_26.1", safari26_1::emulation),
     Safari26_2 => ("safari_26.2", safari26_2::emulation),
+    Safari26_3 => ("safari_26.3", safari26_3::emulation),
+    Safari26_4 => ("safari_26.4", safari26_4::emulation),
     SafariIPad26 => ("safari_ipad_26", safari_ipad_26::emulation),
     SafariIpad26_2 => ("safari_ipad_26.2", safari_ipad_26_2::emulation),
     SafariIos26 => ("safari_ios_26", safari_ios_26::emulation),

--- a/src/emulate/profile/chrome.rs
+++ b/src/emulate/profile/chrome.rs
@@ -1730,6 +1730,39 @@ mod_generator!(
 );
 
 mod_generator!(
+    v148,
+    v132::build_emulation,
+    header_initializer_with_zstd_priority,
+    [
+        (
+            MacOS,
+            r#""Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+        ),
+        (
+            Linux,
+            r#""Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+        ),
+        (
+            Android,
+            r#""Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36"
+        ),
+        (
+            Windows,
+            r#""Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+        ),
+        (
+            IOS,
+            r#""Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/148.0.0.0 Mobile/15E148 Safari/604.1"
+        )
+    ]
+);
+
+mod_generator!(
     edge143,
     v132::build_emulation,
     header_initializer_with_zstd_priority,
@@ -1890,6 +1923,39 @@ mod_generator!(
             IOS,
             r#""Microsoft Edge";v="147", "Not.A/Brand";v="8", "Chromium";v="147""#,
             "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 EdgiOS/147.0.3912.51 Mobile/15E148 Safari/605.1.15"
+        )
+    ]
+);
+
+mod_generator!(
+    edge148,
+    v132::build_emulation,
+    header_initializer_with_zstd_priority,
+    [
+        (
+            MacOS,
+            r#""Chromium";v="148", "Microsoft Edge";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0"
+        ),
+        (
+            Android,
+            r#""Chromium";v="148", "Microsoft Edge";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36 EdgA/148.0.0.0"
+        ),
+        (
+            Windows,
+            r#""Chromium";v="148", "Microsoft Edge";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0"
+        ),
+        (
+            Linux,
+            r#""Chromium";v="148", "Microsoft Edge";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36 Edg/148.0.0.0"
+        ),
+        (
+            IOS,
+            r#""Chromium";v="148", "Microsoft Edge";v="148", "Not/A)Brand";v="99""#,
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 EdgiOS/148.0.0.0 Mobile/15E148 Safari/605.1.15"
         )
     ]
 );

--- a/src/emulate/profile/opera.rs
+++ b/src/emulate/profile/opera.rs
@@ -279,3 +279,21 @@ mod_generator!(
         )
     ]
 );
+
+mod_generator!(
+    opera131,
+    opera116::build_emulation,
+    header_initializer_with_zstd_priority,
+    [
+        (
+            MacOS,
+            r#""Opera";v="131", "Not.A/Brand";v="8", "Chromium";v="147""#,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 OPR/131.0.0.0"
+        ),
+        (
+            Windows,
+            r#""Opera";v="131", "Not.A/Brand";v="8", "Chromium";v="147""#,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36 OPR/131.0.0.0"
+        )
+    ]
+);

--- a/src/emulate/profile/safari.rs
+++ b/src/emulate/profile/safari.rs
@@ -201,6 +201,20 @@ mod_generator!(
 );
 
 mod_generator!(
+    safari26_3,
+    safari18_5::build_emulation,
+    header_initializer_for_18,
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Safari/605.1.15"
+);
+
+mod_generator!(
+    safari26_4,
+    safari18_5::build_emulation,
+    header_initializer_for_18,
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.4 Safari/605.1.15"
+);
+
+mod_generator!(
     safari_ipad_26_2,
     safari26::build_emulation,
     header_initializer_for_18,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added emulation profiles for Chrome 148, Edge 148, Opera 131, Safari 26.3, and Safari 26.4 with platform-specific configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0x676e67/wreq-util/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->