### PR TITLE
fix(emulate): fix HTTP2 configuration for OkHttp

### DIFF
--- a/src/emulate/profile/okhttp.rs
+++ b/src/emulate/profile/okhttp.rs
@@ -98,12 +98,8 @@ fn build_emulation(
             .build();
 
         Http2Options::builder()
-            .initial_window_size(6291456)
-            .initial_connection_window_size(15728640)
-            .max_concurrent_streams(1000)
-            .max_header_list_size(262144)
-            .header_table_size(65536)
-            .headers_stream_dependency(StreamDependency::new(StreamId::zero(), 255, true))
+            .initial_window_size(16777216)
+            .initial_connection_window_size(16777216)
             .headers_pseudo_order(
                 PseudoOrder::builder()
                     .extend([
@@ -124,10 +120,7 @@ fn build_emulation(
         headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
         headers.insert(USER_AGENT, HeaderValue::from_static(user_agent));
         #[cfg(feature = "emulation-compression")]
-        headers.insert(
-            ACCEPT_ENCODING,
-            HeaderValue::from_static("gzip, deflate, br"),
-        );
+        headers.insert(ACCEPT_ENCODING, HeaderValue::from_static("gzip"));
         headers
     });
 

--- a/tests/emulate_okhttp.rs
+++ b/tests/emulate_okhttp.rs
@@ -7,40 +7,40 @@ test_emulation!(
     test_okhttp3_13,
     Emulation::OkHttp3_13,
     ["t13d1613h2_46e7e9700bed_eca864cca44a"],
-    "460a10a98dcc79ed1bf9ab07653d4f79"
+    "605a1154008045d7e3cb3c6fb062c0ce"
 );
 
 test_emulation!(
     test_okhttp3_14,
     Emulation::OkHttp3_14,
     ["t13d1613h2_46e7e9700bed_eca864cca44a"],
-    "460a10a98dcc79ed1bf9ab07653d4f79"
+    "605a1154008045d7e3cb3c6fb062c0ce"
 );
 
 test_emulation!(
     test_okhttp4_9,
     Emulation::OkHttp4_9,
     ["t13d1513h2_8daaf6152771_eca864cca44a"],
-    "460a10a98dcc79ed1bf9ab07653d4f79"
+    "605a1154008045d7e3cb3c6fb062c0ce"
 );
 
 test_emulation!(
     test_okhttp4_10,
     Emulation::OkHttp4_10,
     ["t13d1613h2_46e7e9700bed_eca864cca44a"],
-    "460a10a98dcc79ed1bf9ab07653d4f79"
+    "605a1154008045d7e3cb3c6fb062c0ce"
 );
 
 test_emulation!(
     test_okhttp4_12,
     Emulation::OkHttp4_12,
     ["t13d1613h2_46e7e9700bed_eca864cca44a"],
-    "460a10a98dcc79ed1bf9ab07653d4f79"
+    "605a1154008045d7e3cb3c6fb062c0ce"
 );
 
 test_emulation!(
     test_okhttp5,
     Emulation::OkHttp5,
     ["t13d1613h2_46e7e9700bed_eca864cca44a"],
-    "460a10a98dcc79ed1bf9ab07653d4f79"
+    "605a1154008045d7e3cb3c6fb062c0ce"
 );


### PR DESCRIPTION
I can no longer recall where the original configuration was referenced from, but it does work. Now we're migrating and updating it based on the template parameters of tls_client.