### PR TITLE
feat(emulate): ruzstd backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,14 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-      - name: Tests
+      - name: Tests (zstd)
         run: | 
           set -euxo pipefail
           cargo nextest run --workspace
+      - name: Tests (ruzstd)
+        run: |
+          set -euxo pipefail
+          cargo nextest run --workspace --no-default-features --features "tokio-rt,emulation,zstd-rust"
 
   linux:
     name: Linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [features]
-default = ["emulation"]
+default = ["emulation", "zstd"]
 
 tokio-rt = ["wreq/tokio-rt"]
 compio-rt = ["wreq/compio-rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,14 @@ default = ["emulation"]
 tokio-rt = ["wreq/tokio-rt"]
 compio-rt = ["wreq/compio-rt"]
 
-emulation = ["dep:typed-builder", "dep:brotli", "dep:flate2", "dep:zstd"]
+emulation = ["dep:typed-builder", "dep:brotli", "dep:flate2"]
 emulation-serde = ["dep:serde"]
 emulation-compression = []
 
 tower-delay = ["dep:tower", "dep:pin-project-lite", "tokio/time"]
+
+zstd = ["dep:zstd"]
+zstd-rust = ["dep:ruzstd"]
 
 [dependencies]
 wreq = { version = "6.0.0-rc", default-features = false }
@@ -43,6 +46,7 @@ pin-project-lite = { version = "0.2.17", optional = true }
 brotli = { version = "8.0.2", optional = true }
 flate2 = { version = "1.1.9", optional = true }
 zstd = { version = "0.13.3", optional = true }
+ruzstd = { version = "0.8.3", optional = true }
 
 [dev-dependencies]
 wreq = "6.0.0-rc"

--- a/src/emulate/compress.rs
+++ b/src/emulate/compress.rs
@@ -1,10 +1,20 @@
 //! Compression algorithms for TLS 1.3 certificate compression.
 
+use std::io::{self, Write};
+
 use brotli::{CompressorWriter as BrotliEncoder, Decompressor as BrotliDecoder};
 use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
-use std::io::{self, Write};
 use wreq::tls::compress::{CertificateCompressionAlgorithm, CertificateCompressor, Codec};
-use zstd::stream::{Decoder as ZstdDecoder, Encoder as ZstdEncoder};
+
+#[cfg(not(any(feature = "zstd", feature = "zstd-rust")))]
+compile_error!(
+    "the `emulation` feature requires a zstd backend: enable `zstd` (default) or `zstd-rust`. \
+     For the pure-Rust backend, use `default-features = false` with \
+     `features = [\"emulation\", \"zstd-rust\"]`."
+);
+
+#[cfg(all(feature = "zstd", feature = "zstd-rust"))]
+use zstd as _;
 
 #[derive(Debug)]
 pub struct BrotliCompressor;
@@ -63,23 +73,56 @@ impl CertificateCompressor for ZlibCompressor {
 
 impl CertificateCompressor for ZstdCompressor {
     fn compress(&self) -> Codec {
-        Codec::Pointer(|input, output| {
-            let mut encoder = ZstdEncoder::new(output, 0)?;
-            encoder.write_all(input)?;
-            encoder.finish()?;
-            Ok(())
-        })
+        Codec::Pointer(zstd_impl::compress)
     }
 
     fn decompress(&self) -> Codec {
-        Codec::Pointer(|input, output| {
-            let mut reader = ZstdDecoder::new(input)?;
-            io::copy(&mut reader, output)?;
-            Ok(())
-        })
+        Codec::Pointer(zstd_impl::decompress)
     }
 
     fn algorithm(&self) -> CertificateCompressionAlgorithm {
         CertificateCompressionAlgorithm::ZSTD
+    }
+}
+
+#[cfg(all(feature = "zstd-rust", not(feature = "zstd")))]
+mod zstd_impl {
+    use ruzstd::{
+        decoding::StreamingDecoder,
+        encoding::{self, CompressionLevel},
+    };
+
+    use super::*;
+
+    pub(super) fn compress(input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
+        // `ruzstd` frame compressor panics if the drain returns an error
+        let compressed = encoding::compress_to_vec(input, CompressionLevel::Fastest);
+        output.write_all(&compressed)
+    }
+
+    pub(super) fn decompress(input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
+        let mut decoder = StreamingDecoder::new(input).map_err(io::Error::other)?;
+        io::copy(&mut decoder, output)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "zstd")]
+mod zstd_impl {
+    use zstd::stream::{Decoder, Encoder};
+
+    use super::*;
+
+    pub(super) fn compress(input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
+        let mut encoder = Encoder::new(output, 0)?;
+        encoder.write_all(input)?;
+        encoder.finish()?;
+        Ok(())
+    }
+
+    pub(super) fn decompress(input: &[u8], output: &mut dyn io::Write) -> io::Result<()> {
+        let mut reader = Decoder::new(input)?;
+        io::copy(&mut reader, output)?;
+        Ok(())
     }
 }

--- a/src/emulate/compress.rs
+++ b/src/emulate/compress.rs
@@ -14,7 +14,7 @@ compile_error!(
 );
 
 #[cfg(all(feature = "zstd", feature = "zstd-rust"))]
-use zstd as _;
+use ruzstd as _;
 
 #[derive(Debug)]
 pub struct BrotliCompressor;

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -1,0 +1,72 @@
+#![cfg(feature = "emulation")]
+
+use wreq::tls::compress::{CertificateCompressor, Codec};
+use wreq_util::emulate::compress::{BrotliCompressor, ZlibCompressor, ZstdCompressor};
+
+fn run(codec: Codec, input: &[u8]) -> std::io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    match codec {
+        Codec::Pointer(func) => func(input, &mut out)?,
+        Codec::Dynamic(func) => func(input, &mut out)?,
+    }
+    Ok(out)
+}
+
+fn assert_roundtrip<C: CertificateCompressor>(compressor: &C) {
+    let big = vec![b'A'; 100_000];
+    let inputs: [&[u8]; 5] = [
+        b"",
+        b"x",
+        b"hello, certificate compression",
+        b"the quick brown fox jumps over the lazy dog",
+        &big,
+    ];
+    for input in inputs {
+        let compressed = run(compressor.compress(), input).expect("compress failed");
+        let restored = run(compressor.decompress(), &compressed).expect("decompress failed");
+        assert_eq!(
+            restored,
+            input,
+            "roundtrip mismatch for {}-byte input",
+            input.len()
+        );
+    }
+}
+
+#[test]
+fn zstd_roundtrip() {
+    assert_roundtrip(&ZstdCompressor);
+}
+
+#[test]
+fn brotli_roundtrip() {
+    assert_roundtrip(&BrotliCompressor);
+}
+
+#[test]
+fn zlib_roundtrip() {
+    assert_roundtrip(&ZlibCompressor);
+}
+
+#[test]
+fn decodes_zstd_sys() {
+    #[rustfmt::skip]
+    const REF_ZSTD_FRAME: &[u8] = &[
+        0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x58, 0x05, 0x03, 0x00, 0xe2, 0x45, 0x15,
+        0x1b, 0x50, 0x4d, 0xdc, 0x63, 0xdf, 0x24, 0xb2, 0x44, 0x29, 0x56, 0xb0,
+        0xc6, 0x32, 0xd6, 0xcc, 0xcc, 0x10, 0x32, 0x32, 0xb2, 0xd8, 0x35, 0xc6,
+        0xcc, 0x4c, 0x08, 0x01, 0x09, 0xc4, 0xc1, 0x50, 0x20, 0x0c, 0x04, 0x01,
+        0xc0, 0x1d, 0x7a, 0x3e, 0x59, 0x16, 0x69, 0xf3, 0xe9, 0x99, 0x29, 0x07,
+        0xb9, 0x44, 0x1b, 0x5f, 0x8a, 0x2e, 0xe3, 0x11, 0x44, 0xae, 0x3d, 0x1f,
+        0x7d, 0xc5, 0x6a, 0x63, 0xbe, 0x37, 0x67, 0x7f, 0x29, 0x62, 0xce, 0x65,
+        0x4a, 0xd1, 0xf4, 0x26, 0xfe, 0x34, 0x2f, 0x4f, 0xa8, 0x9d, 0x69, 0xb9,
+        0x4a, 0x02, 0x00, 0x5d, 0x34, 0x2c, 0xe2, 0x52, 0x51,
+    ];
+    const PLAINTEXT: &[u8] =
+        b"wreq-util zstd cert-compression test vector: the quick brown fox jumps \
+          over the lazy dog 0123456789 0123456789 0123456789";
+
+    let restored =
+        run(ZstdCompressor.decompress(), REF_ZSTD_FRAME).expect("decompress zstd-sys frame");
+    assert_eq!(restored, PLAINTEXT);
+}


### PR DESCRIPTION
Compiling `zstd-sys` takes ~8.8s and forces a C toolchain, which is a major pain point for cross-compilation, `musl`, and minimal Docker images.

Changes:
- Split zstd into mutually exclusive features: `zstd` (default) and `zstd-rust` (opt-in).
- `emulation` no longer implies a zstd backend. 
- Added `tests/compress.rs` with round-trip tests and verification against reference zstd frames generated by zstd-sys.
- Added CI coverage for the pure-Rust backend.

Benchmarks (`cargo build --timings` self-time):
- `zstd` (default): ~8.8s 
- `zstd-rust` (this PR): ~0.8s 
