### PR TITLE
feat(emulate): Add Chrome 149

### DIFF
--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -59,6 +59,7 @@ define_enum!(
     Chrome146 => ("chrome_146", v146::emulation),
     Chrome147 => ("chrome_147", v147::emulation),
     Chrome148 => ("chrome_148", v148::emulation),
+    Chrome149 => ("chrome_149", v149::emulation),
 
     // Edge versions
     Edge101 => ("edge_101", edge101::emulation),
@@ -299,7 +300,7 @@ impl Emulation {
                 weight: 7141,
                 platforms: &[Windows, MacOS, Linux, Android],
                 profiles: &[
-                    Chrome148, Chrome147, Chrome146, Chrome145, Chrome144, Chrome143,
+                    Chrome149, Chrome148, Chrome147, Chrome146, Chrome145, Chrome144, Chrome143,
                 ],
             },
             Class {

--- a/src/emulate/profile/chrome.rs
+++ b/src/emulate/profile/chrome.rs
@@ -1763,6 +1763,39 @@ mod_generator!(
 );
 
 mod_generator!(
+    v149,
+    v132::build_emulation,
+    header_initializer_with_zstd_priority,
+    [
+        (
+            MacOS,
+            r#""Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24""#,
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+        ),
+        (
+            Linux,
+            r#""Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24""#,
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+        ),
+        (
+            Android,
+            r#""Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24""#,
+            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Mobile Safari/537.36"
+        ),
+        (
+            Windows,
+            r#""Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24""#,
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+        ),
+        (
+            IOS,
+            r#""Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24""#,
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/149.0.0.0 Mobile/15E148 Safari/604.1"
+        )
+    ]
+);
+
+mod_generator!(
     edge143,
     v132::build_emulation,
     header_initializer_with_zstd_priority,


### PR DESCRIPTION
Added Chrome 149 to Emulation profiles and included it in weighted version selector.

Validated against Chrome 147 using tls.peet.ws:
- JA4 matched: t13d1516h2_8daaf6152771_d8a2da3f94cd.
- Akamai HTTP/2 hash matched: 52d84b11737d980aef856699f885ca86.
- Ran `cargo check --features tokio-rt`.