### PR TITLE
fix(emulate): Fix chrome accept header `q` value

### DIFF
--- a/src/emulate/macros.rs
+++ b/src/emulate/macros.rs
@@ -109,7 +109,7 @@ macro_rules! header_chrome_ua {
 
 macro_rules! header_chrome_accept {
     ($headers:expr) => {
-        $headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"));
+        $headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
         #[cfg(feature = "emulation-compression")]
         $headers.insert(
             ACCEPT_ENCODING,
@@ -118,7 +118,7 @@ macro_rules! header_chrome_accept {
         $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
     };
     (zstd, $headers:expr) => {
-        $headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"));
+        $headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
         #[cfg(feature = "emulation-compression")]
         $headers.insert(
             ACCEPT_ENCODING,


### PR DESCRIPTION
final q value in accept header is set to 0.9 but it should be 0.7
to test, open chrome and go to `https://tls.peet.ws/api/all`