### PR TITLE
fix: correct header order and add missing headers in emulation profiles

### DIFF
--- a/src/emulate/macros.rs
+++ b/src/emulate/macros.rs
@@ -130,7 +130,7 @@ macro_rules! header_chrome_accept_encoding {
             HeaderValue::from_static("gzip, deflate, br, zstd"),
         );
         $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
-    }
+    };
 }
 
 macro_rules! header_firefox_sec_fetch {

--- a/src/emulate/macros.rs
+++ b/src/emulate/macros.rs
@@ -95,9 +95,10 @@ macro_rules! header_chrome_sec_ch_ua {
 
 macro_rules! header_chrome_sec_fetch {
     ($headers:expr) => {
-        $headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-        $headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
         $headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+        $headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+        $headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
+        $headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
     };
 }
 
@@ -110,6 +111,11 @@ macro_rules! header_chrome_ua {
 macro_rules! header_chrome_accept {
     ($headers:expr) => {
         $headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
+    };
+}
+
+macro_rules! header_chrome_accept_encoding {
+    ($headers:expr) => {
         #[cfg(feature = "emulation-compression")]
         $headers.insert(
             ACCEPT_ENCODING,
@@ -118,7 +124,6 @@ macro_rules! header_chrome_accept {
         $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
     };
     (zstd, $headers:expr) => {
-        $headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"));
         #[cfg(feature = "emulation-compression")]
         $headers.insert(
             ACCEPT_ENCODING,
@@ -133,6 +138,7 @@ macro_rules! header_firefox_sec_fetch {
         $headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
         $headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
         $headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+        $headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
     };
 }
 
@@ -144,12 +150,12 @@ macro_rules! header_firefox_accept {
                 "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             ),
         );
+        $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.5"));
         #[cfg(feature = "emulation-compression")]
         $headers.insert(
             ACCEPT_ENCODING,
             HeaderValue::from_static("gzip, deflate, br"),
         );
-        $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.5"));
     };
     (zstd, $headers:expr) => {
         $headers.insert(
@@ -158,21 +164,17 @@ macro_rules! header_firefox_accept {
                 "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             ),
         );
+        $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.5"));
         #[cfg(feature = "emulation-compression")]
         $headers.insert(
             ACCEPT_ENCODING,
             HeaderValue::from_static("gzip, deflate, br, zstd"),
         );
-        $headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.5"));
     };
 }
 
 macro_rules! header_firefox_ua {
     ($headers:expr, $ua:expr) => {
-        $headers.insert(
-            HeaderName::from_static("te"),
-            HeaderValue::from_static("trailers"),
-        );
         $headers.insert(USER_AGENT, HeaderValue::from_static($ua));
     };
 }

--- a/src/emulate/profile/chrome/header.rs
+++ b/src/emulate/profile/chrome/header.rs
@@ -12,9 +12,14 @@ pub fn header_initializer(
         emulation_os.platform(),
         emulation_os.is_mobile()
     );
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
     header_chrome_ua!(headers, ua);
-    header_chrome_sec_fetch!(headers);
     header_chrome_accept!(headers);
+    header_chrome_sec_fetch!(headers);
+    header_chrome_accept_encoding!(headers);
     headers
 }
 
@@ -30,9 +35,14 @@ pub fn header_initializer_with_zstd(
         emulation_os.platform(),
         emulation_os.is_mobile()
     );
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
     header_chrome_ua!(headers, ua);
+    header_chrome_accept!(headers);
     header_chrome_sec_fetch!(headers);
-    header_chrome_accept!(zstd, headers);
+    header_chrome_accept_encoding!(zstd, headers);
     headers
 }
 
@@ -48,9 +58,14 @@ pub fn header_initializer_with_zstd_priority(
         emulation_os.platform(),
         emulation_os.is_mobile()
     );
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
     header_chrome_ua!(headers, ua);
+    header_chrome_accept!(headers);
     header_chrome_sec_fetch!(headers);
-    header_chrome_accept!(zstd, headers);
+    header_chrome_accept_encoding!(zstd, headers);
     headers.insert(
         HeaderName::from_static("priority"),
         HeaderValue::from_static("u=0, i"),

--- a/src/emulate/profile/firefox/header.rs
+++ b/src/emulate/profile/firefox/header.rs
@@ -4,7 +4,15 @@ pub fn header_initializer(ua: &'static str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     header_firefox_ua!(headers, ua);
     header_firefox_accept!(headers);
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
     header_firefox_sec_fetch!(headers);
+    headers.insert(
+        HeaderName::from_static("te"),
+        HeaderValue::from_static("trailers"),
+    );
     headers
 }
 
@@ -12,10 +20,18 @@ pub fn header_initializer_with_zstd(ua: &'static str) -> HeaderMap {
     let mut headers = HeaderMap::new();
     header_firefox_ua!(headers, ua);
     header_firefox_accept!(zstd, headers);
+    headers.insert(
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
+    );
     header_firefox_sec_fetch!(headers);
     headers.insert(
         HeaderName::from_static("priority"),
         HeaderValue::from_static("u=0, i"),
+    );
+    headers.insert(
+        HeaderName::from_static("te"),
+        HeaderValue::from_static("trailers"),
     );
     headers
 }

--- a/src/emulate/profile/opera/header.rs
+++ b/src/emulate/profile/opera/header.rs
@@ -13,15 +13,14 @@ pub fn header_initializer_with_zstd_priority(
         emulation_os.platform(),
         emulation_os.is_mobile()
     );
-    header_chrome_ua!(headers, ua);
-
-    headers.insert(ACCEPT, HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"));
-    #[cfg(feature = "emulation-compression")]
     headers.insert(
-        ACCEPT_ENCODING,
-        HeaderValue::from_static("gzip, deflate, br, zstd"),
+        HeaderName::from_static("upgrade-insecure-requests"),
+        HeaderValue::from_static("1"),
     );
-    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
+    header_chrome_ua!(headers, ua);
+    header_chrome_accept!(headers);
+    header_chrome_sec_fetch!(headers);
+    header_chrome_accept_encoding!(zstd, headers);
     headers.insert(
         HeaderName::from_static("priority"),
         HeaderValue::from_static("u=0, i"),


### PR DESCRIPTION
## Summary

- Fix header order for Chrome/Firefox/Opera to match real browsers
- Add missing `Upgrade-Insecure-Requests` and `Sec-Fetch-User` headers

Resolves 0x676e67/wreq#751.

## Before / After

**Chrome** (verified against Chrome 150 via [tls.peet.ws](https://tls.peet.ws/api/all)):

| Before | After (matches real Chrome) |
|--------|----------------------------|
| sec-ch-ua | sec-ch-ua |
| sec-ch-ua-mobile | sec-ch-ua-mobile |
| sec-ch-ua-platform | sec-ch-ua-platform |
| user-agent | **upgrade-insecure-requests** |
| **sec-fetch-dest** | user-agent |
| **sec-fetch-mode** | accept |
| **sec-fetch-site** | **sec-fetch-site** |
| accept | **sec-fetch-mode** |
| accept-encoding | **sec-fetch-user** |
| accept-language | **sec-fetch-dest** |
| priority | accept-encoding |
| | accept-language |
| | priority |

**Firefox** (verified against Firefox 151 via [tls.peet.ws](https://tls.peet.ws/api/all)):

| Before | After (matches real Firefox) |
|--------|------------------------------|
| **te** | user-agent |
| user-agent | accept |
| accept | **accept-language** |
| **accept-encoding** | **accept-encoding** |
| **accept-language** | **upgrade-insecure-requests** |
| sec-fetch-dest | sec-fetch-dest |
| sec-fetch-mode | sec-fetch-mode |
| sec-fetch-site | sec-fetch-site |
| | **sec-fetch-user** |
| | priority |
| | **te** |

**Opera** (verified against Opera 133 via [tls.peet.ws](https://tls.peet.ws/api/all)):
- Added missing `sec-fetch-site`, `sec-fetch-mode`, `sec-fetch-user`, `sec-fetch-dest`
- Added missing `upgrade-insecure-requests`
- Fixed `Accept` header value (`q=0.9` → `q=0.7`, matching current Chromium)
- Fixed header order to match Chrome

**Safari**: no changes needed — existing profiles confirmed correct via WebKit source analysis.

## Source code references

- Chromium `sec-fetch-*` order hardcoded as Site→Mode→User→Dest in [`sec_header_helpers.cc#L295-L299`](https://source.chromium.org/chromium/chromium/src/+/main:services/network/sec_header_helpers.cc;l=295-299)
- Gecko `sec-fetch-*` order hardcoded as Dest→Mode→Site→User in [`SecFetch.cpp#L400-L403`](https://searchfox.org/mozilla-central/source/dom/security/SecFetch.cpp#400-403)