### PR TITLE
feat(emulate): add fetch header ordering strategy

### DIFF
--- a/src/emulate.rs
+++ b/src/emulate.rs
@@ -2,6 +2,7 @@
 mod macros;
 pub mod compress;
 pub mod profile;
+pub(crate) mod wtf_hash;
 
 use profile::{chrome::*, firefox::*, okhttp::*, opera::*, safari::*};
 #[cfg(feature = "emulation-serde")]
@@ -187,6 +188,13 @@ define_enum!(
     IOS => "ios"
 );
 
+define_enum!(
+    plain,
+    Strategy, Navigate,
+    Navigate => "navigate",
+    Fetch => "fetch"
+);
+
 impl Platform {
     #[inline]
     const fn platform(&self) -> &'static str {
@@ -227,6 +235,9 @@ pub struct Emulation {
     /// Whether to include default headers.
     #[builder(default = true)]
     headers: bool,
+
+    #[builder(default)]
+    strategy: Strategy,
 }
 
 impl Emulation {

--- a/src/emulate/macros.rs
+++ b/src/emulate/macros.rs
@@ -240,12 +240,14 @@ macro_rules! platform_headers {
                         $other_sec_ch_ua,
                         $other_ua,
                         $emulation.platform,
+                        $emulation.strategy,
                     ),
                 )*
                 _ => $header_initializer(
                     $default_sec_ch_ua,
                     $default_ua,
                     Platform::$default_os,
+                    $emulation.strategy,
                 ),
             }
         })

--- a/src/emulate/macros.rs
+++ b/src/emulate/macros.rs
@@ -87,18 +87,18 @@ macro_rules! define_enum {
 macro_rules! header_chrome_sec_ch_ua {
     ($headers:expr, $ua:expr, $platform:expr, $is_mobile:expr) => {
         let mobile = if $is_mobile { "?1" } else { "?0" };
-        $headers.insert("sec-ch-ua", HeaderValue::from_static($ua));
-        $headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
-        $headers.insert("sec-ch-ua-platform", HeaderValue::from_static($platform));
+        $headers.insert(SEC_CH_UA, HeaderValue::from_static($ua));
+        $headers.insert(SEC_CH_UA_MOBILE, HeaderValue::from_static(mobile));
+        $headers.insert(SEC_CH_UA_PLATFORM, HeaderValue::from_static($platform));
     };
 }
 
 macro_rules! header_chrome_sec_fetch {
     ($headers:expr) => {
-        $headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-        $headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-        $headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
-        $headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+        $headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+        $headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("navigate"));
+        $headers.insert(SEC_FETCH_USER, HeaderValue::from_static("?1"));
+        $headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("document"));
     };
 }
 
@@ -135,10 +135,10 @@ macro_rules! header_chrome_accept_encoding {
 
 macro_rules! header_firefox_sec_fetch {
     ($headers:expr) => {
-        $headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
-        $headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
-        $headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-        $headers.insert("sec-fetch-user", HeaderValue::from_static("?1"));
+        $headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("document"));
+        $headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("navigate"));
+        $headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+        $headers.insert(SEC_FETCH_USER, HeaderValue::from_static("?1"));
     };
 }
 

--- a/src/emulate/profile.rs
+++ b/src/emulate/profile.rs
@@ -23,7 +23,7 @@ use wreq::{
 };
 
 use super::{
-    Emulation, Platform,
+    Emulation, Platform, Strategy,
     compress::{BrotliCompressor, ZlibCompressor, ZstdCompressor},
 };
 

--- a/src/emulate/profile.rs
+++ b/src/emulate/profile.rs
@@ -27,6 +27,17 @@ use super::{
     compress::{BrotliCompressor, ZlibCompressor, ZstdCompressor},
 };
 
+const SEC_CH_UA: HeaderName = HeaderName::from_static("sec-ch-ua");
+const SEC_CH_UA_MOBILE: HeaderName = HeaderName::from_static("sec-ch-ua-mobile");
+const SEC_CH_UA_PLATFORM: HeaderName = HeaderName::from_static("sec-ch-ua-platform");
+const UPGRADE_INSECURE_REQUESTS: HeaderName = HeaderName::from_static("upgrade-insecure-requests");
+const SEC_FETCH_SITE: HeaderName = HeaderName::from_static("sec-fetch-site");
+const SEC_FETCH_MODE: HeaderName = HeaderName::from_static("sec-fetch-mode");
+const SEC_FETCH_USER: HeaderName = HeaderName::from_static("sec-fetch-user");
+const SEC_FETCH_DEST: HeaderName = HeaderName::from_static("sec-fetch-dest");
+const PRIORITY: HeaderName = HeaderName::from_static("priority");
+const TE: HeaderName = HeaderName::from_static("te");
+
 fn build_standard_emulation(
     group: &'static str,
     tls_options: TlsOptions,

--- a/src/emulate/profile/chrome/header.rs
+++ b/src/emulate/profile/chrome/header.rs
@@ -17,7 +17,7 @@ pub fn header_initializer(
                 emulation_os.is_mobile()
             );
             headers.insert(
-                HeaderName::from_static("upgrade-insecure-requests"),
+                UPGRADE_INSECURE_REQUESTS,
                 HeaderValue::from_static("1"),
             );
             header_chrome_ua!(headers, ua);
@@ -36,14 +36,14 @@ pub fn header_initializer(
             ]) {
                 match name {
                     "sec-ch-ua" => {
-                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                        headers.insert(SEC_CH_UA, HeaderValue::from_static(sec_ch_ua));
                     }
                     "sec-ch-ua-mobile" => {
-                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                        headers.insert(SEC_CH_UA_MOBILE, HeaderValue::from_static(mobile));
                     }
                     "sec-ch-ua-platform" => {
                         headers.insert(
-                            "sec-ch-ua-platform",
+                            SEC_CH_UA_PLATFORM,
                             HeaderValue::from_static(platform),
                         );
                     }
@@ -54,9 +54,9 @@ pub fn header_initializer(
                 }
             }
             headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
-            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
-            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+            headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("cors"));
+            headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("empty"));
             header_chrome_accept_encoding!(headers);
         }
     }
@@ -79,7 +79,7 @@ pub fn header_initializer_with_zstd(
                 emulation_os.is_mobile()
             );
             headers.insert(
-                HeaderName::from_static("upgrade-insecure-requests"),
+                UPGRADE_INSECURE_REQUESTS,
                 HeaderValue::from_static("1"),
             );
             header_chrome_ua!(headers, ua);
@@ -98,14 +98,14 @@ pub fn header_initializer_with_zstd(
             ]) {
                 match name {
                     "sec-ch-ua" => {
-                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                        headers.insert(SEC_CH_UA, HeaderValue::from_static(sec_ch_ua));
                     }
                     "sec-ch-ua-mobile" => {
-                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                        headers.insert(SEC_CH_UA_MOBILE, HeaderValue::from_static(mobile));
                     }
                     "sec-ch-ua-platform" => {
                         headers.insert(
-                            "sec-ch-ua-platform",
+                            SEC_CH_UA_PLATFORM,
                             HeaderValue::from_static(platform),
                         );
                     }
@@ -116,9 +116,9 @@ pub fn header_initializer_with_zstd(
                 }
             }
             headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
-            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
-            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+            headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("cors"));
+            headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("empty"));
             header_chrome_accept_encoding!(zstd, headers);
         }
     }
@@ -141,7 +141,7 @@ pub fn header_initializer_with_zstd_priority(
                 emulation_os.is_mobile()
             );
             headers.insert(
-                HeaderName::from_static("upgrade-insecure-requests"),
+                UPGRADE_INSECURE_REQUESTS,
                 HeaderValue::from_static("1"),
             );
             header_chrome_ua!(headers, ua);
@@ -149,7 +149,7 @@ pub fn header_initializer_with_zstd_priority(
             header_chrome_sec_fetch!(headers);
             header_chrome_accept_encoding!(zstd, headers);
             headers.insert(
-                HeaderName::from_static("priority"),
+                PRIORITY,
                 HeaderValue::from_static("u=0, i"),
             );
         }
@@ -164,14 +164,14 @@ pub fn header_initializer_with_zstd_priority(
             ]) {
                 match name {
                     "sec-ch-ua" => {
-                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                        headers.insert(SEC_CH_UA, HeaderValue::from_static(sec_ch_ua));
                     }
                     "sec-ch-ua-mobile" => {
-                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                        headers.insert(SEC_CH_UA_MOBILE, HeaderValue::from_static(mobile));
                     }
                     "sec-ch-ua-platform" => {
                         headers.insert(
-                            "sec-ch-ua-platform",
+                            SEC_CH_UA_PLATFORM,
                             HeaderValue::from_static(platform),
                         );
                     }
@@ -182,12 +182,12 @@ pub fn header_initializer_with_zstd_priority(
                 }
             }
             headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
-            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
-            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+            headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("cors"));
+            headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("empty"));
             header_chrome_accept_encoding!(zstd, headers);
             headers.insert(
-                HeaderName::from_static("priority"),
+                PRIORITY,
                 HeaderValue::from_static("u=1, i"),
             );
         }

--- a/src/emulate/profile/chrome/header.rs
+++ b/src/emulate/profile/chrome/header.rs
@@ -1,25 +1,65 @@
 use super::*;
+use crate::emulate::wtf_hash;
 
 pub fn header_initializer(
     sec_ch_ua: &'static str,
     ua: &'static str,
     emulation_os: Platform,
+    strategy: Strategy,
 ) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    header_chrome_sec_ch_ua!(
-        headers,
-        sec_ch_ua,
-        emulation_os.platform(),
-        emulation_os.is_mobile()
-    );
-    headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
-        HeaderValue::from_static("1"),
-    );
-    header_chrome_ua!(headers, ua);
-    header_chrome_accept!(headers);
-    header_chrome_sec_fetch!(headers);
-    header_chrome_accept_encoding!(headers);
+    match strategy {
+        Strategy::Navigate => {
+            header_chrome_sec_ch_ua!(
+                headers,
+                sec_ch_ua,
+                emulation_os.platform(),
+                emulation_os.is_mobile()
+            );
+            headers.insert(
+                HeaderName::from_static("upgrade-insecure-requests"),
+                HeaderValue::from_static("1"),
+            );
+            header_chrome_ua!(headers, ua);
+            header_chrome_accept!(headers);
+            header_chrome_sec_fetch!(headers);
+            header_chrome_accept_encoding!(headers);
+        }
+        Strategy::Fetch => {
+            let mobile = if emulation_os.is_mobile() { "?1" } else { "?0" };
+            let platform = emulation_os.platform();
+            for name in wtf_hash::header_order(&[
+                "sec-ch-ua",
+                "sec-ch-ua-mobile",
+                "sec-ch-ua-platform",
+                "user-agent",
+            ]) {
+                match name {
+                    "sec-ch-ua" => {
+                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                    }
+                    "sec-ch-ua-mobile" => {
+                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                    }
+                    "sec-ch-ua-platform" => {
+                        headers.insert(
+                            "sec-ch-ua-platform",
+                            HeaderValue::from_static(platform),
+                        );
+                    }
+                    "user-agent" => {
+                        header_chrome_ua!(headers, ua);
+                    }
+                    _ => {}
+                }
+            }
+            headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
+            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
+            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            header_chrome_accept_encoding!(headers);
+        }
+    }
     headers
 }
 
@@ -27,22 +67,61 @@ pub fn header_initializer_with_zstd(
     sec_ch_ua: &'static str,
     ua: &'static str,
     emulation_os: Platform,
+    strategy: Strategy,
 ) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    header_chrome_sec_ch_ua!(
-        headers,
-        sec_ch_ua,
-        emulation_os.platform(),
-        emulation_os.is_mobile()
-    );
-    headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
-        HeaderValue::from_static("1"),
-    );
-    header_chrome_ua!(headers, ua);
-    header_chrome_accept!(headers);
-    header_chrome_sec_fetch!(headers);
-    header_chrome_accept_encoding!(zstd, headers);
+    match strategy {
+        Strategy::Navigate => {
+            header_chrome_sec_ch_ua!(
+                headers,
+                sec_ch_ua,
+                emulation_os.platform(),
+                emulation_os.is_mobile()
+            );
+            headers.insert(
+                HeaderName::from_static("upgrade-insecure-requests"),
+                HeaderValue::from_static("1"),
+            );
+            header_chrome_ua!(headers, ua);
+            header_chrome_accept!(headers);
+            header_chrome_sec_fetch!(headers);
+            header_chrome_accept_encoding!(zstd, headers);
+        }
+        Strategy::Fetch => {
+            let mobile = if emulation_os.is_mobile() { "?1" } else { "?0" };
+            let platform = emulation_os.platform();
+            for name in wtf_hash::header_order(&[
+                "sec-ch-ua",
+                "sec-ch-ua-mobile",
+                "sec-ch-ua-platform",
+                "user-agent",
+            ]) {
+                match name {
+                    "sec-ch-ua" => {
+                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                    }
+                    "sec-ch-ua-mobile" => {
+                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                    }
+                    "sec-ch-ua-platform" => {
+                        headers.insert(
+                            "sec-ch-ua-platform",
+                            HeaderValue::from_static(platform),
+                        );
+                    }
+                    "user-agent" => {
+                        header_chrome_ua!(headers, ua);
+                    }
+                    _ => {}
+                }
+            }
+            headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
+            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
+            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            header_chrome_accept_encoding!(zstd, headers);
+        }
+    }
     headers
 }
 
@@ -50,25 +129,68 @@ pub fn header_initializer_with_zstd_priority(
     sec_ch_ua: &'static str,
     ua: &'static str,
     emulation_os: Platform,
+    strategy: Strategy,
 ) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    header_chrome_sec_ch_ua!(
-        headers,
-        sec_ch_ua,
-        emulation_os.platform(),
-        emulation_os.is_mobile()
-    );
-    headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
-        HeaderValue::from_static("1"),
-    );
-    header_chrome_ua!(headers, ua);
-    header_chrome_accept!(headers);
-    header_chrome_sec_fetch!(headers);
-    header_chrome_accept_encoding!(zstd, headers);
-    headers.insert(
-        HeaderName::from_static("priority"),
-        HeaderValue::from_static("u=0, i"),
-    );
+    match strategy {
+        Strategy::Navigate => {
+            header_chrome_sec_ch_ua!(
+                headers,
+                sec_ch_ua,
+                emulation_os.platform(),
+                emulation_os.is_mobile()
+            );
+            headers.insert(
+                HeaderName::from_static("upgrade-insecure-requests"),
+                HeaderValue::from_static("1"),
+            );
+            header_chrome_ua!(headers, ua);
+            header_chrome_accept!(headers);
+            header_chrome_sec_fetch!(headers);
+            header_chrome_accept_encoding!(zstd, headers);
+            headers.insert(
+                HeaderName::from_static("priority"),
+                HeaderValue::from_static("u=0, i"),
+            );
+        }
+        Strategy::Fetch => {
+            let mobile = if emulation_os.is_mobile() { "?1" } else { "?0" };
+            let platform = emulation_os.platform();
+            for name in wtf_hash::header_order(&[
+                "sec-ch-ua",
+                "sec-ch-ua-mobile",
+                "sec-ch-ua-platform",
+                "user-agent",
+            ]) {
+                match name {
+                    "sec-ch-ua" => {
+                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                    }
+                    "sec-ch-ua-mobile" => {
+                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                    }
+                    "sec-ch-ua-platform" => {
+                        headers.insert(
+                            "sec-ch-ua-platform",
+                            HeaderValue::from_static(platform),
+                        );
+                    }
+                    "user-agent" => {
+                        header_chrome_ua!(headers, ua);
+                    }
+                    _ => {}
+                }
+            }
+            headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
+            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
+            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            header_chrome_accept_encoding!(zstd, headers);
+            headers.insert(
+                HeaderName::from_static("priority"),
+                HeaderValue::from_static("u=1, i"),
+            );
+        }
+    }
     headers
 }

--- a/src/emulate/profile/firefox/header.rs
+++ b/src/emulate/profile/firefox/header.rs
@@ -5,12 +5,12 @@ pub fn header_initializer(ua: &'static str) -> HeaderMap {
     header_firefox_ua!(headers, ua);
     header_firefox_accept!(headers);
     headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
+        UPGRADE_INSECURE_REQUESTS,
         HeaderValue::from_static("1"),
     );
     header_firefox_sec_fetch!(headers);
     headers.insert(
-        HeaderName::from_static("te"),
+        TE,
         HeaderValue::from_static("trailers"),
     );
     headers
@@ -21,16 +21,16 @@ pub fn header_initializer_with_zstd(ua: &'static str) -> HeaderMap {
     header_firefox_ua!(headers, ua);
     header_firefox_accept!(zstd, headers);
     headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
+        UPGRADE_INSECURE_REQUESTS,
         HeaderValue::from_static("1"),
     );
     header_firefox_sec_fetch!(headers);
     headers.insert(
-        HeaderName::from_static("priority"),
+        PRIORITY,
         HeaderValue::from_static("u=0, i"),
     );
     headers.insert(
-        HeaderName::from_static("te"),
+        TE,
         HeaderValue::from_static("trailers"),
     );
     headers

--- a/src/emulate/profile/opera/header.rs
+++ b/src/emulate/profile/opera/header.rs
@@ -18,7 +18,7 @@ pub fn header_initializer_with_zstd_priority(
                 emulation_os.is_mobile()
             );
             headers.insert(
-                HeaderName::from_static("upgrade-insecure-requests"),
+                UPGRADE_INSECURE_REQUESTS,
                 HeaderValue::from_static("1"),
             );
             header_chrome_ua!(headers, ua);
@@ -26,7 +26,7 @@ pub fn header_initializer_with_zstd_priority(
             header_chrome_sec_fetch!(headers);
             header_chrome_accept_encoding!(zstd, headers);
             headers.insert(
-                HeaderName::from_static("priority"),
+                PRIORITY,
                 HeaderValue::from_static("u=0, i"),
             );
         }
@@ -46,13 +46,13 @@ pub fn header_initializer_with_zstd_priority(
             for name in order {
                 match name {
                     "sec-ch-ua" => {
-                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                        headers.insert(SEC_CH_UA, HeaderValue::from_static(sec_ch_ua));
                     }
                     "sec-ch-ua-mobile" => {
-                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                        headers.insert(SEC_CH_UA_MOBILE, HeaderValue::from_static(mobile));
                     }
                     "sec-ch-ua-platform" => {
-                        headers.insert("sec-ch-ua-platform", HeaderValue::from_static(platform));
+                        headers.insert(SEC_CH_UA_PLATFORM, HeaderValue::from_static(platform));
                     }
                     "user-agent" => {
                         header_chrome_ua!(headers, ua);
@@ -61,12 +61,12 @@ pub fn header_initializer_with_zstd_priority(
                 }
             }
             headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
-            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
-            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+            headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("cors"));
+            headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("empty"));
             header_chrome_accept_encoding!(zstd, headers);
             headers.insert(
-                HeaderName::from_static("priority"),
+                PRIORITY,
                 HeaderValue::from_static("u=1, i"),
             );
         }

--- a/src/emulate/profile/opera/header.rs
+++ b/src/emulate/profile/opera/header.rs
@@ -1,29 +1,75 @@
 use super::*;
+use crate::emulate::wtf_hash;
 
 #[inline]
 pub fn header_initializer_with_zstd_priority(
     sec_ch_ua: &'static str,
     ua: &'static str,
     emulation_os: Platform,
+    strategy: Strategy,
 ) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    header_chrome_sec_ch_ua!(
-        headers,
-        sec_ch_ua,
-        emulation_os.platform(),
-        emulation_os.is_mobile()
-    );
-    headers.insert(
-        HeaderName::from_static("upgrade-insecure-requests"),
-        HeaderValue::from_static("1"),
-    );
-    header_chrome_ua!(headers, ua);
-    header_chrome_accept!(headers);
-    header_chrome_sec_fetch!(headers);
-    header_chrome_accept_encoding!(zstd, headers);
-    headers.insert(
-        HeaderName::from_static("priority"),
-        HeaderValue::from_static("u=0, i"),
-    );
+    match strategy {
+        Strategy::Navigate => {
+            header_chrome_sec_ch_ua!(
+                headers,
+                sec_ch_ua,
+                emulation_os.platform(),
+                emulation_os.is_mobile()
+            );
+            headers.insert(
+                HeaderName::from_static("upgrade-insecure-requests"),
+                HeaderValue::from_static("1"),
+            );
+            header_chrome_ua!(headers, ua);
+            header_chrome_accept!(headers);
+            header_chrome_sec_fetch!(headers);
+            header_chrome_accept_encoding!(zstd, headers);
+            headers.insert(
+                HeaderName::from_static("priority"),
+                HeaderValue::from_static("u=0, i"),
+            );
+        }
+        Strategy::Fetch => {
+            let mobile = if emulation_os.is_mobile() {
+                "?1"
+            } else {
+                "?0"
+            };
+            let platform = emulation_os.platform();
+            let order = wtf_hash::header_order(&[
+                "sec-ch-ua",
+                "sec-ch-ua-mobile",
+                "sec-ch-ua-platform",
+                "user-agent",
+            ]);
+            for name in order {
+                match name {
+                    "sec-ch-ua" => {
+                        headers.insert("sec-ch-ua", HeaderValue::from_static(sec_ch_ua));
+                    }
+                    "sec-ch-ua-mobile" => {
+                        headers.insert("sec-ch-ua-mobile", HeaderValue::from_static(mobile));
+                    }
+                    "sec-ch-ua-platform" => {
+                        headers.insert("sec-ch-ua-platform", HeaderValue::from_static(platform));
+                    }
+                    "user-agent" => {
+                        header_chrome_ua!(headers, ua);
+                    }
+                    _ => {}
+                }
+            }
+            headers.insert(ACCEPT, HeaderValue::from_static("*/*"));
+            headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+            headers.insert("sec-fetch-mode", HeaderValue::from_static("cors"));
+            headers.insert("sec-fetch-dest", HeaderValue::from_static("empty"));
+            header_chrome_accept_encoding!(zstd, headers);
+            headers.insert(
+                HeaderName::from_static("priority"),
+                HeaderValue::from_static("u=1, i"),
+            );
+        }
+    }
     headers
 }

--- a/src/emulate/profile/safari/header.rs
+++ b/src/emulate/profile/safari/header.rs
@@ -24,32 +24,32 @@ pub fn header_initializer_for_16_17(ua: &'static str) -> HeaderMap {
         ACCEPT,
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
-    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
+    headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
     #[cfg(feature = "emulation-compression")]
     headers.insert(
         ACCEPT_ENCODING,
         HeaderValue::from_static("gzip, deflate, br"),
     );
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("navigate"));
     headers.insert(USER_AGENT, HeaderValue::from_static(ua));
     headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+    headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("document"));
     headers
 }
 
 #[inline]
 pub fn header_initializer_for_18(ua: &'static str) -> HeaderMap {
     let mut headers = HeaderMap::new();
-    headers.insert("sec-fetch-dest", HeaderValue::from_static("document"));
+    headers.insert(SEC_FETCH_DEST, HeaderValue::from_static("document"));
     headers.insert(USER_AGENT, HeaderValue::from_static(ua));
     headers.insert(
         ACCEPT,
         HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
     );
-    headers.insert("sec-fetch-site", HeaderValue::from_static("none"));
-    headers.insert("sec-fetch-mode", HeaderValue::from_static("navigate"));
+    headers.insert(SEC_FETCH_SITE, HeaderValue::from_static("none"));
+    headers.insert(SEC_FETCH_MODE, HeaderValue::from_static("navigate"));
     headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
-    headers.insert("priority", HeaderValue::from_static("u=0, i"));
+    headers.insert(PRIORITY, HeaderValue::from_static("u=0, i"));
     #[cfg(feature = "emulation-compression")]
     headers.insert(
         ACCEPT_ENCODING,

--- a/src/emulate/wtf_hash.rs
+++ b/src/emulate/wtf_hash.rs
@@ -1,0 +1,271 @@
+const RAPID_SEED: u64 = 0xbdd89aa982704029;
+const RAPID_SECRET: [u64; 3] = [0x2d358dccaa6c78a5, 0x8bb84b93962eacc9, 0x4b33a62ed433d4a3];
+
+fn rapid_mul128(a: u64, b: u64) -> (u64, u64) {
+    let r = (a as u128) * (b as u128);
+    (r as u64, (r >> 64) as u64)
+}
+
+fn rapid_mix(a: u64, b: u64) -> u64 {
+    let (lo, hi) = rapid_mul128(a, b);
+    lo ^ hi
+}
+
+fn case_fold(ch: u8) -> u64 {
+    if ch.is_ascii_uppercase() {
+        (ch - b'A' + b'a') as u64
+    } else {
+        ch as u64
+    }
+}
+
+fn cf_read64(p: &[u8]) -> u64 {
+    case_fold(p[0])
+        | (case_fold(p[1]) << 16)
+        | (case_fold(p[2]) << 32)
+        | (case_fold(p[3]) << 48)
+}
+
+fn cf_read32(p: &[u8]) -> u64 {
+    case_fold(p[0]) | (case_fold(p[1]) << 16)
+}
+
+fn rapidhash_case_folding(data: &[u8]) -> u64 {
+    let p = data;
+    let len = data.len() * 2;
+
+    let mut seed = RAPID_SEED;
+    seed ^= rapid_mix(seed ^ RAPID_SECRET[0], RAPID_SECRET[1]) ^ (len as u64);
+
+    let (a, b);
+
+    if len <= 16 {
+        if len >= 4 {
+            let plast = p.len() - 2;
+            a = (cf_read32(p) << 32) | cf_read32(&p[plast..]);
+            let delta = ((len & 24) >> (len >> 3)) / 2;
+            b = (cf_read32(&p[delta..]) << 32) | cf_read32(&p[plast - delta..]);
+        } else if len > 0 {
+            a = case_fold(p[0]);
+            b = 0;
+        } else {
+            a = 0;
+            b = 0;
+        }
+    } else {
+        let mut i = len;
+        let mut pp = 0usize;
+        seed = if i > 48 {
+            let mut see1 = seed;
+            let mut see2 = seed;
+            let mut s = seed;
+            while i >= 48 {
+                s = rapid_mix(cf_read64(&p[pp..]) ^ RAPID_SECRET[0], cf_read64(&p[pp + 4..]) ^ s);
+                see1 = rapid_mix(
+                    cf_read64(&p[pp + 8..]) ^ RAPID_SECRET[1],
+                    cf_read64(&p[pp + 12..]) ^ see1,
+                );
+                see2 = rapid_mix(
+                    cf_read64(&p[pp + 16..]) ^ RAPID_SECRET[2],
+                    cf_read64(&p[pp + 20..]) ^ see2,
+                );
+                pp += 24;
+                i -= 48;
+            }
+            s ^ see1 ^ see2
+        } else {
+            seed
+        };
+
+        if i > 16 {
+            seed = rapid_mix(
+                cf_read64(&p[pp..]) ^ RAPID_SECRET[2],
+                cf_read64(&p[pp + 4..]) ^ seed ^ RAPID_SECRET[1],
+            );
+            if i > 32 {
+                seed = rapid_mix(
+                    cf_read64(&p[pp + 8..]) ^ RAPID_SECRET[2],
+                    cf_read64(&p[pp + 12..]) ^ seed,
+                );
+            }
+        }
+
+        let si = i as isize;
+        let a_off = pp as isize + (si - 16) / 2;
+        let b_off = pp as isize + (si - 8) / 2;
+        a = cf_read64(&p[a_off as usize..]);
+        b = cf_read64(&p[b_off as usize..]);
+    }
+
+    let a = a ^ RAPID_SECRET[1];
+    let b = b ^ seed;
+    let (a, b) = rapid_mul128(a, b);
+    rapid_mix(a ^ RAPID_SECRET[0] ^ (len as u64), b ^ RAPID_SECRET[1])
+}
+
+fn wtf_hash(name: &str) -> u32 {
+    let mut r = rapidhash_case_folding(name.as_bytes()) as u32;
+    r &= (1u32 << 24) - 1;
+    if r == 0 {
+        r = 1u32 << 23;
+    }
+    r
+}
+
+const EMPTY: i32 = -1;
+const MIN_CAP: usize = 8;
+
+pub(crate) fn header_order<'a>(names: &[&'a str]) -> Vec<&'a str> {
+    let n = names.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    let hashes: Vec<u32> = names.iter().map(|n| wtf_hash(n)).collect();
+
+    let mut cap = MIN_CAP;
+    let mut slots = vec![EMPTY; cap];
+    let mut count = 0usize;
+
+    for (idx, &h) in hashes.iter().enumerate() {
+        let mask = cap - 1;
+        let mut pos = (h as usize) & mask;
+        let mut probe = 0usize;
+        while slots[pos] != EMPTY {
+            probe += 1;
+            pos = (pos + probe) & mask;
+        }
+        slots[pos] = idx as i32;
+        count += 1;
+
+        if count * 2 >= cap {
+            let old_cap = cap;
+            cap *= 2;
+            let mut new_slots = vec![EMPTY; cap];
+            let mask = cap - 1;
+            for i in 0..old_cap {
+                let item = slots[i];
+                if item == EMPTY {
+                    continue;
+                }
+                let mut pos = (hashes[item as usize] as usize) & mask;
+                let mut probe = 0usize;
+                while new_slots[pos] != EMPTY {
+                    probe += 1;
+                    pos = (pos + probe) & mask;
+                }
+                new_slots[pos] = item;
+            }
+            slots = new_slots;
+        }
+    }
+
+    let mut result = Vec::with_capacity(n);
+    for &item in &slots {
+        if item != EMPTY {
+            result.push(names[item as usize]);
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_fetch() {
+        let order = header_order(&[
+            "sec-ch-ua",
+            "sec-ch-ua-mobile",
+            "sec-ch-ua-platform",
+            "user-agent",
+        ]);
+        assert_eq!(
+            order,
+            &["sec-ch-ua-platform", "user-agent", "sec-ch-ua", "sec-ch-ua-mobile"]
+        );
+    }
+
+    #[test]
+    fn test_fetch_with_custom_headers() {
+        let order = header_order(&[
+            "x-custom-first",
+            "x-custom-second",
+            "sec-ch-ua",
+            "sec-ch-ua-mobile",
+            "sec-ch-ua-platform",
+            "user-agent",
+        ]);
+        assert_eq!(
+            order,
+            &[
+                "x-custom-second",
+                "sec-ch-ua-platform",
+                "user-agent",
+                "sec-ch-ua",
+                "x-custom-first",
+                "sec-ch-ua-mobile"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_fetch_with_many_custom_headers() {
+        let order = header_order(&[
+            "x-alpha",
+            "x-beta",
+            "x-delta",
+            "x-epsilon",
+            "x-gamma",
+            "sec-ch-ua",
+            "sec-ch-ua-mobile",
+            "sec-ch-ua-platform",
+            "user-agent",
+        ]);
+        assert_eq!(
+            order,
+            &[
+                "x-alpha",
+                "sec-ch-ua-platform",
+                "sec-ch-ua",
+                "x-gamma",
+                "sec-ch-ua-mobile",
+                "x-beta",
+                "x-epsilon",
+                "x-delta",
+                "user-agent"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_fetch_post_content_type() {
+        let order = header_order(&[
+            "content-type",
+            "sec-ch-ua",
+            "sec-ch-ua-mobile",
+            "sec-ch-ua-platform",
+            "user-agent",
+        ]);
+        assert_eq!(
+            order,
+            &[
+                "sec-ch-ua-platform",
+                "user-agent",
+                "sec-ch-ua",
+                "content-type",
+                "sec-ch-ua-mobile"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_hash_known_values() {
+        assert_eq!(wtf_hash("sec-ch-ua"), 0x33F009);
+        assert_eq!(wtf_hash("sec-ch-ua-mobile"), 0x9B488D);
+        assert_eq!(wtf_hash("sec-ch-ua-platform"), 0xFFBEC3);
+        assert_eq!(wtf_hash("user-agent"), 0xC21178);
+        assert_eq!(wtf_hash("accept"), 0x592219);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,4 @@ mod rand;
 pub mod tower;
 
 #[cfg(feature = "emulation")]
-pub use self::emulate::{Emulation, Platform, Profile};
+pub use self::emulate::{Emulation, Platform, Profile, Strategy};


### PR DESCRIPTION
## Summary

Implements the header-ordering strategy discussed in #104.

- Add `Strategy` enum (`Navigate` / `Fetch`) to `Emulation`
- Add `wtf_hash` module: Chromium's CaseFolding rapidhash + quadratic-probing hash table simulation
- Chrome/Edge/Opera header initializers branch on `strategy` to produce correct order and values

Default is `Navigate`, existing behavior unchanged.

## Navigate vs Fetch

| | Navigate | Fetch |
|---|---|---|
| Header order | Insertion order (`std::vector`) | Hash iteration order (`WTF::HashMap`) |
| accept | `text/html,...` | `*/*` |
| sec-fetch-mode | `navigate` | `cors` |
| sec-fetch-user | `?1` | absent |
| sec-fetch-dest | `document` | `empty` |
| upgrade-insecure-requests | `1` | absent |
| priority | `u=0, i` | `u=1, i` |

## Hash function version

Chromium switched `WTF::StringHasher` from SuperFastHash to rapidhash at Chrome 129 ([`string_hasher.h`](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/wtf/text/string_hasher.h)). The `wtf_hash` module implements rapidhash, so `Strategy::Fetch` produces exact header order for Chrome ≥ 129. Profiles for Chrome 100–128 use rapidhash as an approximation — header values are correct, only the Blink-layer order may differ slightly.

## Verified against

Chrome 150 + [pingly.us.kg](https://pingly.us.kg/), 4 scenarios: default fetch, custom headers, 5 custom headers, POST with content-type.